### PR TITLE
fix: linear-gradient angles that crash on older Android

### DIFF
--- a/app/src/main/res/drawable/bg_hero_gradient.xml
+++ b/app/src/main/res/drawable/bg_hero_gradient.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
-        android:angle="160"
+        android:angle="135"
         android:startColor="@color/gradient_start"
         android:centerColor="@color/gradient_mid"
         android:endColor="@color/gradient_end" />

--- a/app/src/main/res/drawable/bg_hero_gradient_error.xml
+++ b/app/src/main/res/drawable/bg_hero_gradient_error.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
-        android:angle="160"
+        android:angle="135"
         android:startColor="#4A0010"
         android:centerColor="#7B1030"
         android:endColor="#B71C4A" />

--- a/app/src/main/res/drawable/bg_toolbar_gradient.xml
+++ b/app/src/main/res/drawable/bg_toolbar_gradient.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
-        android:angle="150"
+        android:angle="135"
         android:startColor="@color/gradient_start"
         android:endColor="@color/gradient_mid" />
 </shape>


### PR DESCRIPTION
## Summary
- Older Android (and some OEM skins) require a linear-gradient `angle` to be a multiple of 45. `150` and `160` crashed: FilterListActivity on inflate (`Resources$NotFoundException` / `XmlPullParserException`), and other screens on draw (`IllegalArgumentException`).
- Snapped `bg_toolbar_gradient`, `bg_hero_gradient`, and `bg_hero_gradient_error` to `135`, the nearest valid diagonal already used by `bg_time_button_selected`.

## Test plan
- [ ] Open the app filter / whitelist page on an older device or emulator (API 27–28, or a Huawei skin): it should open without crashing.
- [ ] Confirm the toolbar and home hero still look like a diagonal gradient, not a solid fill.
- [ ] Navigate other screens that use the hero / toolbar drawables and confirm they draw without crashing.


Made with [Cursor](https://cursor.com)